### PR TITLE
Supply a different neo4j version number to neo4j-community chart

### DIFF
--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -49,6 +49,7 @@ neo4j-community:
   defaultDatabase: "graph.db"
   # For better security, add password to neo4j-secrets k8s secret and uncomment below
   existingPasswordSecret: neo4j-secrets
+  imageTag: "4.2.15"
 
 mysql:
   enabled: true


### PR DESCRIPTION
I also found that having a dedicated fort for equinor/helm-charts so I created it,
but I didn't change this chart to reference it.

## Reference
https://stackoverflow.com/questions/55748639/set-value-in-dependency-of-helm-chart
